### PR TITLE
Task: CSS Bayan

### DIFF
--- a/cssBayan/index.html
+++ b/cssBayan/index.html
@@ -91,7 +91,7 @@
             </div>
         </main>
         <footer class="container_footer">
-            <a class="container_footer_links_git" href="">GitHub</a>
+            <a class="container_footer_links_git" href=""> GitHub</a>
         </footer>
     </body>
 </html>

--- a/cssBayan/index.html
+++ b/cssBayan/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <!--<meta http-equiv="refresh" content="0;URL=/#2"/>      -->
         <link rel="stylesheet" href="./style.css">
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -118,11 +118,6 @@ body{
     font-size: calc(20px + 5 * ((100vw - 320px) / (1920 - 320))); 
     visibility: hidden;  
 } 
-.open_mem{
-   
-
-}
-
 :target .container_main_wrap_bayan_item_mem_image{ 
     height: calc(200px + 290 * ((100vw - 320px) / (1920 - 320))); 
     overflow: visible;

--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -44,7 +44,6 @@ body{
 }
 .container_main_wrap_bayan:hover .container_main_wrap_bayan_item .container_main_wrap_bayan_item_text .active_wrap{
     visibility: visible;
-    
 }
 
 .container_main_wrap_bayan_item {
@@ -54,7 +53,6 @@ body{
     flex-direction: column;
     justify-content: center;
     text-decoration: none;
-
 }
 .container_main_wrap_bayan_item_text {
     font-family: 'Tilt Warp';
@@ -65,17 +63,12 @@ body{
     color: rgb(55, 74, 216);
     margin-bottom: calc(10px + 10 * ((100vw - 320px) / (1920 - 320))); 
     height: calc(20px + 30 * ((100vw - 320px) / (1920 - 320))); 
-  
 }
-
-
 .container_main_wrap_bayan_item:hover .container_main_wrap_bayan_item_mem_image{
     height: calc(200px + 290 * ((100vw - 320px) / (1920 - 320))); 
     overflow: visible;
     opacity: 1;
     transition: .7s;
-
-
 }
 .container_main_wrap_bayan_item:hover .container_main_wrap_bayan_item_mem_image img{
     transition: .7s;
@@ -83,7 +76,6 @@ body{
 }
 .container_main_wrap_bayan_item:hover .active_wrap{
     transform: rotate(45deg);
-
 }
 .container_main_wrap_bayan_item_mem_image{
     display: flex;
@@ -98,8 +90,6 @@ body{
     transform: scale(0);
     transition: .7s;
 }
-
-
 .container_main_wrap_bayan_item_mem_image img{
     width: calc(160px + 260 * ((100vw - 320px) / (1920 - 320))); 
     padding-bottom: calc(10px + 15 * ((100vw - 320px) / (1920 - 320))); 
@@ -126,8 +116,7 @@ body{
     position: absolute;
     right: 0.625rem;
     font-size: calc(20px + 5 * ((100vw - 320px) / (1920 - 320))); 
-    visibility: hidden;
-    
+    visibility: hidden;  
 } 
 .open_mem{
    
@@ -146,7 +135,6 @@ body{
  }
  :target .open_mem{
     transform: rotate(45deg);
-
 }
 :target .container_main_wrap_bayan_item_text{ 
 color: black;


### PR DESCRIPTION
1. Task: https://github.com/DrDiman/CSS-Bayan-task
2. Screenshot:
![maksimyou github io_cssBayan_cssBayan_](https://user-images.githubusercontent.com/93248333/224332031-eca6d630-78f4-4825-b84f-0d6a329948a7.png)
3.  Deploy: https://maksimyou.github.io/cssBayan/cssBayan/
4.  Done 10.03.2023 / deadline 13.03.2023
5. Score: 135 / 140
   -Everything is done from Repository requirements and how to submit task section +30   +
   -The accordion component is centered on the screen, with equal indents on the left and right +10  +
   -Icons, meme texts and meme images are exist +5 +
   -Placement of the meme, icons and meme text are the same as in provided example gif images +5 +
   -Smooth change (transition) of the meme images and icons is done +20  +
   -Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080 +10 +
   -All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented +10 +
   -The entire row (text, icon, and meme image) clickable +5 +
   -Mobile first approach is used - cursor over the memes (hover) effect exists only for desktop devices +10 +
   -The cursor when it is hovering over the rows of the accordion is changing +5 +
   -Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive +10 +
   -All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static +5 +
   -Pseudo-elements are not used (note: pseudo-classes are allowed) +5 +
   -Initially, the first meme should be expanded +5 -
   -Font size is changed at each device (mobile, tablet, desktop) +5 +
